### PR TITLE
update: 그룹/그룹 상세 페이지 업데이트

### DIFF
--- a/src/components/modal/GroupCreateModal.tsx
+++ b/src/components/modal/GroupCreateModal.tsx
@@ -50,6 +50,7 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
     setImageSrc('');
     setTagSet([]);
     setThumbnail('');
+    setgroupInfos({ ...groupInfos, description: '' });
   };
 
   const addTag = () => {
@@ -111,6 +112,7 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
       setImageSrc('');
       setTagSet([]);
       setThumbnail('');
+      setgroupInfos({ ...groupInfos, description: '' });
     }
     // else {
     //   alert('형식을 모두 작성해주세요');
@@ -118,6 +120,27 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
   };
 
   const accessToken = sessionStorage.getItem('accessToken');
+
+  const limitLines = (e: any) => {
+    let rows = e.target.value.split('\n')?.length; //줄바꿈 개수
+    let maxRows = 4;
+    if (rows > maxRows) {
+      const { name, value } = e.target;
+      setgroupInfos({
+        ...groupInfos,
+        [name]: value.split('\n').slice(0, maxRows).join('\n'),
+      });
+    } else {
+      const { name, value } = e.target;
+      setgroupInfos({ ...groupInfos, [name]: value });
+    }
+  };
+
+  const handlekeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      addTag();
+    }
+  };
 
   return (
     <div>
@@ -177,8 +200,9 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
                   <input
                     onChange={e => setTag(e.target.value)}
                     value={tag}
-                    placeholder="태그를 추가해주세요. (최대 3개)"
+                    placeholder="태그를 추가해주세요. (최대 5개)"
                     maxLength={8}
+                    onKeyDown={handlekeyDown}
                   />
                   <div onClick={addTag} className="tag-plus">
                     +
@@ -204,8 +228,12 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
                 <p>그룹 소개</p>
                 <textarea
                   name="description"
-                  onChange={e => handleGroupInfo(e)}
+                  onChange={e => {
+                    handleGroupInfo(e);
+                    limitLines(e);
+                  }}
                   maxLength={100}
+                  value={groupInfos.description}
                 ></textarea>
               </StGroupTextArea>
               <StGroupBtn

--- a/src/components/modal/GroupDetailCreateModal.tsx
+++ b/src/components/modal/GroupDetailCreateModal.tsx
@@ -61,11 +61,7 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
     setImageSrc([]);
     setRoute('');
     setThumbnail([]);
-  };
-
-  const handleGroupInfo = (e: any) => {
-    const { name, value } = e.target;
-    setgroupInfos({ ...groupInfos, [name]: value });
+    setgroupInfos({ ...groupInfos, description: '' });
   };
 
   const handleSetThumbnail = (e: any) => {
@@ -104,6 +100,7 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
       setImageSrc([]);
       setRoute('');
       setThumbnail([]);
+      setgroupInfos({ ...groupInfos, description: '' });
       alert('게시글 작성 완료!');
     }
   };
@@ -111,6 +108,26 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
   useEffect(() => {
     dispatch(__getMap());
   }, []);
+
+  // const handleGroupInfo = (e: any) => {
+  //   const { name, value } = e.target;
+  //   setgroupInfos({ ...groupInfos, [name]: value });
+  // };
+
+  const limitLines = (e: any) => {
+    let rows = e.target.value.split('\n')?.length; //줄바꿈 개수
+    let maxRows = 4;
+    if (rows > maxRows) {
+      const { name, value } = e.target;
+      setgroupInfos({
+        ...groupInfos,
+        [name]: value.split('\n').slice(0, maxRows).join('\n'),
+      });
+    } else {
+      const { name, value } = e.target;
+      setgroupInfos({ ...groupInfos, [name]: value });
+    }
+  };
 
   return (
     <div>
@@ -245,8 +262,12 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
                 <p>내용 작성</p>
                 <textarea
                   name="description"
-                  onChange={e => handleGroupInfo(e)}
+                  onChange={e => {
+                    // handleGroupInfo(e);
+                    limitLines(e);
+                  }}
                   maxLength={100}
+                  value={groupInfos.description}
                 ></textarea>
               </StGroupTextArea>
               <StGroupBtn onClick={sendData}>모두 작성했어요!</StGroupBtn>
@@ -584,6 +605,7 @@ const StGroupTextArea = styled.div`
   * {
     box-sizing: border-box;
   }
+
   p {
     color: gray;
     font-size: 13px;
@@ -599,6 +621,7 @@ const StGroupTextArea = styled.div`
     height: 100%;
     text-indent: 5px;
     resize: none;
+    /* white-space: pre-wrap; */
   }
 `;
 

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -158,7 +158,9 @@ const GroupDetail = () => {
 
             <div className="group-intro">
               <h2>그룹 소개</h2>
-              <p>{filteredByPage[0]?.description}</p>
+              <p style={{ whiteSpace: 'pre-wrap' }}>
+                {filteredByPage[0]?.description}
+              </p>
             </div>
             {groupSubscribe ? (
               groupSubscribe.admin_flag ? (

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -177,22 +177,14 @@ const GroupPage = () => {
       <StRecommendLists>
         {tags?.map((tag: any, index) => {
           return index === 0 ? (
-            <StTagsContainer>
-              <div
-                className="tag tag-ml tag-all"
-                onClick={() => setTag('ALL')}
-                key={index}
-              >
+            <StTagsContainer key={index}>
+              <div className="tag tag-ml tag-all" onClick={() => setTag('ALL')}>
                 {`ALL`}
               </div>
             </StTagsContainer>
           ) : (
-            <StTagsContainer>
-              <div
-                className="tag"
-                onClick={() => setTag(tag.title)}
-                key={index}
-              >
+            <StTagsContainer key={index}>
+              <div className="tag" onClick={() => setTag(tag.title)}>
                 {tag.title}
               </div>
             </StTagsContainer>

--- a/src/pages/subpages/GroupDetailCard.tsx
+++ b/src/pages/subpages/GroupDetailCard.tsx
@@ -158,7 +158,7 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
     fetchData();
   };
 
-  const toggleHeart = async (feedId: number) => {
+  const toggleThumb = async (feedId: number) => {
     await loggedIn.put(`/api/group/${groupId}/feed/${feedId}/like`); //좋아요 / 좋아요 취소 api
     dispatch(__groupFeedList({ id: groupId, userId: userId }));
   };
@@ -221,24 +221,22 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
               <StIcon>
                 <p>{likeCount}</p>
                 <i
-                  className="ri-heart-3-fill"
-                  style={{ color: 'red', fontSize: '25px' }}
-                  onClick={() => toggleHeart(feed_id)}
+                  onClick={() => toggleThumb(feed_id)}
+                  style={{ color: 'blue', fontSize: '25px' }}
+                  className="ri-thumb-up-fill"
                 ></i>
               </StIcon>
             ) : (
               <StIcon>
                 <p>{likeCount}</p>
                 <i
-                  className="ri-heart-3-line"
-                  onClick={() => toggleHeart(feed_id)}
-                  style={{ color: 'red', fontSize: '25px' }}
+                  onClick={() => toggleThumb(feed_id)}
+                  style={{ color: 'blue', fontSize: '25px' }}
+                  className="ri-thumb-up-line"
                 ></i>
               </StIcon>
             )}
           </div>
-          {/* <div className="post-bottom-icon">B</div>
-          <div className="post-bottom-icon">C</div> */}
           {userId === user_id ? (
             <div className="post-bottom-icon">
               <StIcon>
@@ -298,7 +296,7 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
                   <p>{mbti.toUpperCase()}</p>
                 </div>
                 <StDiv>
-                  {description}
+                  <p style={{ whiteSpace: 'pre-wrap' }}>{description}</p>
                   {parsedLocation.place_group_name !== '없음' ? (
                     !toggleRoute ? (
                       <div className="route-open">
@@ -322,7 +320,11 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
                         </p>
                         {parsedPlace?.map((route: any, index: number) => {
                           return (
-                            <div key={index} className="route-close-list">
+                            <div
+                              onClick={() => setToggleRoute(false)}
+                              key={index}
+                              className="route-close-list"
+                            >
                               <svg
                                 xmlns="http://www.w3.org/2000/svg"
                                 width="13"
@@ -350,18 +352,18 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
                       <StIcon>
                         <p>{likeCount}</p>
                         <i
-                          className="ri-heart-3-fill"
-                          style={{ color: 'red', fontSize: '25px' }}
-                          onClick={() => toggleHeart(feed_id)}
+                          onClick={() => toggleThumb(feed_id)}
+                          style={{ color: 'blue', fontSize: '25px' }}
+                          className="ri-thumb-up-fill"
                         ></i>
                       </StIcon>
                     ) : (
                       <StIcon>
                         <p>{likeCount}</p>
                         <i
-                          className="ri-heart-3-line"
-                          style={{ color: 'red', fontSize: '25px' }}
-                          onClick={() => toggleHeart(feed_id)}
+                          onClick={() => toggleThumb(feed_id)}
+                          style={{ color: 'blue', fontSize: '25px' }}
+                          className="ri-thumb-up-line"
                         ></i>
                       </StIcon>
                     )}
@@ -466,18 +468,22 @@ const StDiv = styled.div`
     background-color: #f6f4fd;
     box-shadow: 0 0px 4px 0 rgba(0, 0, 0, 0.25);
     margin-top: 10px;
-    cursor: pointer;
-    padding: 5px 10px;
+    /* cursor: pointer; */
+    /* padding: 5px 10px; */
     border-radius: 5px;
     z-index: 10;
     /* left: -4px; */
 
     .route-open-button {
+      cursor: pointer;
+      padding: 5px 10px;
       font-size: 10px;
       color: gray;
     }
 
     .route-close-button {
+      cursor: pointer;
+      padding: 5px 10px;
       font-size: 10px;
       color: gray;
     }
@@ -502,7 +508,7 @@ const StDiv = styled.div`
       display: flex;
       align-items: center;
       /* justify-content: center; */
-      padding-top: 5px;
+      padding: 2px 5px;
       height: 20px;
       p {
         font-size: 11px;
@@ -631,6 +637,7 @@ const StDetailDesc = styled.div`
     border-radius: 50%;
   }
   .detail-info {
+    /* word-break: break-all; */
     position: relative;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
좋아요 표시 하트에서 떰업으로 바꿈.
다음 라인으로 갈 수 있는 최대 수 4줄로 한정.
그룹 생성 시 태그 엔터로 추가 가능.
루트 펼치기 하단 루트들 포인터 없앰.
#1 #7