### PR TITLE
update: 그룹/그룹 상세 페이지 업데이트

### DIFF
--- a/src/components/modal/GroupCreateModal.tsx
+++ b/src/components/modal/GroupCreateModal.tsx
@@ -113,6 +113,7 @@ const GroupCreateModal: React.FC<Props> = ({ filterGroup }) => {
       setTagSet([]);
       setThumbnail('');
       setgroupInfos({ ...groupInfos, description: '' });
+      window.scrollTo(0, 0);
     }
     // else {
     //   alert('형식을 모두 작성해주세요');

--- a/src/components/modal/GroupDetailCreateModal.tsx
+++ b/src/components/modal/GroupDetailCreateModal.tsx
@@ -8,7 +8,10 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 
 import { useAppDispatch, useAppSelector } from '../hooks/typescripthook/hooks';
-import { __groupFeedList } from '../../redux/modules/groupSlice';
+import {
+  __groupFeedList,
+  __groupGetRank,
+} from '../../redux/modules/groupSlice';
 import loggedIn from '../../api/loggedIn';
 import { __getMap } from '../../redux/modules/mySlice';
 
@@ -77,7 +80,9 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
       `api/group/${paramId.id}/feed?user_id=${userId}`,
       formData,
     );
-    await dispatch(__groupFeedList({ id: paramId.id, userId: userId }));
+    await dispatch(__groupFeedList({ id: paramId.id, userId: userId })); //그룹 게시글 업데이트
+    await dispatch(__groupGetRank()); //그룹 정보 업데이트
+    //두개 다 해줘야함 ㅋ
   };
 
   const sendData = async () => {
@@ -102,6 +107,7 @@ const GroupDetailCreateModal: React.FC<Props> = ({ paramId }) => {
       setThumbnail([]);
       setgroupInfos({ ...groupInfos, description: '' });
       alert('게시글 작성 완료!');
+      window.scrollTo(0, 0);
     }
   };
 

--- a/src/pages/MbtiQuestionsPage.tsx
+++ b/src/pages/MbtiQuestionsPage.tsx
@@ -64,8 +64,11 @@ const MbtiQuestionsPage = () => {
                 value="E"
                 type="radio"
                 onChange={getMbti}
+                id="firstMBTIYes"
               />
-              <label className="yes-label">그렇다</label>
+              <label htmlFor="firstMBTIYes" className="yes-label">
+                그렇다
+              </label>
             </StInput>
             <StInput>
               <input
@@ -73,8 +76,11 @@ const MbtiQuestionsPage = () => {
                 value="I"
                 type="radio"
                 onChange={getMbti}
+                id="firstMBTINo"
               />
-              <label className="no-label">그렇지 않다</label>
+              <label htmlFor="firstMBTINo" className="no-label">
+                그렇지 않다
+              </label>
             </StInput>
           </StInputContainer>
         </StQuestion>
@@ -87,8 +93,11 @@ const MbtiQuestionsPage = () => {
                 value="S"
                 type="radio"
                 onChange={getMbti}
+                id="secondMBTIYes"
               />
-              <label className="yes-label">그렇다</label>
+              <label htmlFor="secondMBTIYes" className="yes-label">
+                그렇다
+              </label>
             </StInput>
             <StInput>
               <input
@@ -96,8 +105,11 @@ const MbtiQuestionsPage = () => {
                 value="N"
                 type="radio"
                 onChange={getMbti}
+                id="secondMBTINo"
               />
-              <label className="no-label">그렇지 않다</label>
+              <label htmlFor="secondMBTINo" className="no-label">
+                그렇지 않다
+              </label>
             </StInput>
           </StInputContainer>
         </StQuestion>
@@ -110,8 +122,11 @@ const MbtiQuestionsPage = () => {
                 value="F"
                 type="radio"
                 onChange={getMbti}
+                id="thirdMBTIYes"
               />
-              <label className="yes-label">그렇다</label>
+              <label htmlFor="thirdMBTIYes" className="yes-label">
+                그렇다
+              </label>
             </StInput>
             <StInput>
               <input
@@ -119,8 +134,11 @@ const MbtiQuestionsPage = () => {
                 value="T"
                 type="radio"
                 onChange={getMbti}
+                id="thirdMBTINo"
               />
-              <label className="no-label">그렇지 않다</label>
+              <label htmlFor="thirdMBTINo" className="no-label">
+                그렇지 않다
+              </label>
             </StInput>
           </StInputContainer>
         </StQuestion>
@@ -133,8 +151,11 @@ const MbtiQuestionsPage = () => {
                 value="J"
                 type="radio"
                 onChange={getMbti}
+                id="fourthMBTIYes"
               />
-              <label className="yes-label">그렇다</label>
+              <label htmlFor="fourthMBTIYes" className="yes-label">
+                그렇다
+              </label>
             </StInput>
             <StInput>
               <input
@@ -142,8 +163,11 @@ const MbtiQuestionsPage = () => {
                 value="P"
                 type="radio"
                 onChange={getMbti}
+                id="fourthMBTINo"
               />
-              <label className="no-label">그렇지 않다</label>
+              <label htmlFor="fourthMBTINo" className="no-label">
+                그렇지 않다
+              </label>
             </StInput>
           </StInputContainer>
         </StQuestion>

--- a/src/pages/subpages/GroupDetailCard.tsx
+++ b/src/pages/subpages/GroupDetailCard.tsx
@@ -12,7 +12,10 @@ import {
   useAppDispatch,
   useAppSelector,
 } from '../../components/hooks/typescripthook/hooks';
-import { __groupFeedList } from '../../redux/modules/groupSlice';
+import {
+  __groupFeedList,
+  __groupGetRank,
+} from '../../redux/modules/groupSlice';
 import loggedIn from '../../api/loggedIn';
 import nonTokenClient from '../../api/noClient';
 
@@ -165,9 +168,11 @@ const GroupDetailCard: React.FC<feedCardPreset> = ({
 
   const deletePost = async () => {
     if (window.confirm('정말로 이 게시글을 삭제하시겠습니까?')) {
-      await loggedIn.delete(`/api/group/${groupId}/feed/${feed_id}`); //좋아요 / 좋아요 취소 api
-      dispatch(__groupFeedList({ id: groupId, userId: userId }));
+      await loggedIn.delete(`/api/group/${groupId}/feed/${feed_id}`);
+      dispatch(__groupFeedList({ id: groupId, userId: userId })); //삭제 후 그룹 상세 리스트 업데이트
+      dispatch(__groupGetRank()); //그룹 정보 업데이트
       alert('게시글이 삭제되었습니다!');
+      window.scrollTo(0, 0);
     } else {
       // alert('취소합니다.');
     }


### PR DESCRIPTION
그룹 / 그룹 상세 페이지 생성 / 삭제 시 화면 최상단으로 이동하게 함.
mbti 간편 검사에서 그렇다 / 그렇지 않다 글자 클릭시 버튼이 클릭 되게 함.
그룹 게시글 생성 / 삭제 후 게시물 개수가 바로 변경 되도록 수정
#1 #4 #7 #19 #20 