### PR TITLE
fix: 메인 페이지 에러 수정

### DIFF
--- a/src/pages/subpages/MainPostCard.tsx
+++ b/src/pages/subpages/MainPostCard.tsx
@@ -423,7 +423,7 @@ const MainPostCard: React.FC<Props> = ({
                 </div>
 
                 <StDiv>
-                  {description}
+                  <p className="modal-desc">{description}</p>
                   {parsedLocation.place_group_name !== '없음' ? (
                     !toggleRoute ? (
                       <div className="route-open">
@@ -827,6 +827,11 @@ const StDiv = styled.div`
   position: relative;
   font-size: 13px;
   margin-bottom: 10px;
+
+  .modal-desc {
+    word-break: break-all;
+    white-space: pre-wrap;
+  }
 
   .route-open,
   .route-close {


### PR DESCRIPTION
메인 게시글 모달에서 숫자로 쳤을 때 모달창이 깨지는 에러 수정.
마이 페이지에서 글 생성시 엔터키가 포함된 글이 그대로 안 보이던 문제 수정
#25